### PR TITLE
Fix #3: Could you consider giving an option to turrets?

### DIFF
--- a/Languages/ChineseSimplified/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/ChineseSimplified/Keyed/FALCFF_LanguageData.xml
@@ -17,4 +17,10 @@
 
   <FALCFF.EnableWhenUndrafted>未征兵时始终启用</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>如果您在战斗中频繁禁用“禁用同伴射击”的设定，则使用此选项。如果未征兵，则始终启用禁止误伤。</FALCFF.EnableWhenUndraftedDesc>
+
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
 </LanguageData>

--- a/Languages/ChineseTraditional/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/ChineseTraditional/Keyed/FALCFF_LanguageData.xml
@@ -17,4 +17,10 @@
 
   <FALCFF.EnableWhenUndrafted>未征兵時始終啓用</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>如果您在戰鬥中頻繁禁用“禁用同伴射擊”的設定，則使用此選項。如果未征兵，則始終啓用禁止誤傷。</FALCFF.EnableWhenUndraftedDesc>
+
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
 </LanguageData>

--- a/Languages/English/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/English/Keyed/FALCFF_LanguageData.xml
@@ -18,6 +18,12 @@
   <FALCFF.EnableWhenUndrafted>Always enable when undrafted</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>If you tend to disable the 'Avoid Friendly Fire' setting on pawns during combat, using this option will ensure it is always turned back on again when they are undrafted.</FALCFF.EnableWhenUndraftedDesc>
 
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
+
   <FALCFF.EnableAccurateMissRadius>Use accurate miss radius</FALCFF.EnableAccurateMissRadius>
   <FALCFF.EnableAccurateMissRadiusDesc>Low skill shooters have a larger miss radius than higher skilled ones and this mod accounts for that. If this setting is disabled, the mod will assume a one tile miss radius for all shooters, which will be more lenient to low skill shooters but may result in more friendly fire hits.</FALCFF.EnableAccurateMissRadiusDesc>
 

--- a/Languages/Japanese/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/Japanese/Keyed/FALCFF_LanguageData.xml
@@ -19,6 +19,12 @@
   <FALCFF.EnableWhenUndrafted>徴兵されてない時は常に有効</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>もしあなたが戦闘中にポーンで「味方撃ちを無効」の設定を頻繁に無効化するようでしたら、このオプションを使用すると、徴兵されていない場合、常に再びオンに戻ります。</FALCFF.EnableWhenUndraftedDesc>
 
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
+
   <FALCFF.EnableAccurateMissRadius>正確なミス半径を使用</FALCFF.EnableAccurateMissRadius>
   <FALCFF.EnableAccurateMissRadiusDesc>スキルの低い射手はスキルの高い射手よりも命中ミスをする半径が大きく、このModではそれを反映しています。この設定が無効になっていると、Modはすべての射手に対してミスの半径を1タイルに仮設定します。これはスキルの低い射手にはより優しいですが、結果的により多く味方への誤射が発生します。</FALCFF.EnableAccurateMissRadiusDesc>
 

--- a/Languages/Spanish/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/Spanish/Keyed/FALCFF_LanguageData.xml
@@ -17,4 +17,10 @@
 
   <FALCFF.EnableWhenUndrafted>Reactivar siempre que no se esté peleando</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>Si tiende a desactivar la opción "Avoid Friendly Fire" en colonos durante el combate, al usar esta opción se asegura de que siempre vuelva a activarse de nuevo cuando no estén en combate.</FALCFF.EnableWhenUndraftedDesc>
+
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/SpanishLatin/Keyed/FALCFF_LanguageData.xml
@@ -17,4 +17,10 @@
 
   <FALCFF.EnableWhenUndrafted>Reactivar siempre que no se esté peleando</FALCFF.EnableWhenUndrafted>
   <FALCFF.EnableWhenUndraftedDesc>Si tiende a desactivar la opción "Avoid Friendly Fire" en colonos durante el combate, al usar esta opción se asegura de que siempre vuelva a activarse de nuevo cuando no estén en combate.</FALCFF.EnableWhenUndraftedDesc>
+
+  <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
+  <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
+  <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>
 </LanguageData>

--- a/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
+++ b/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
@@ -10,9 +10,16 @@ namespace AvoidFriendlyFire
         private Dictionary<int, ExtendedPawnData> _store =
             new Dictionary<int, ExtendedPawnData>();
 
+        private Dictionary<int, ExtendedTurretData> _turretStore =
+            new Dictionary<int, ExtendedTurretData>();
+
         private List<int> _idWorkingList;
 
         private List<ExtendedPawnData> _extendedPawnDataWorkingList;
+
+        private List<int> _turretIdWorkingList;
+
+        private List<ExtendedTurretData> _extendedTurretDataWorkingList;
 
 
         public override void ExposeData()
@@ -22,6 +29,10 @@ namespace AvoidFriendlyFire
                 ref _store, "store", 
                 LookMode.Value, LookMode.Deep, 
                 ref _idWorkingList, ref _extendedPawnDataWorkingList);
+            Scribe_Collections.Look(
+                ref _turretStore, "turretStore",
+                LookMode.Value, LookMode.Deep,
+                ref _turretIdWorkingList, ref _extendedTurretDataWorkingList);
         }
 
         // Return the associate extended data for a given Pawn, creating a new association
@@ -60,9 +71,52 @@ namespace AvoidFriendlyFire
             return true;
         }
 
+        public ExtendedTurretData GetExtendedDataFor(Thing turret)
+        {
+            var id = turret.thingIDNumber;
+            if (_turretStore.TryGetValue(id, out ExtendedTurretData data))
+            {
+                return data;
+            }
+
+            var newExtendedData = new ExtendedTurretData();
+            _turretStore[id] = newExtendedData;
+            return newExtendedData;
+        }
+
+        public bool CanTrackTurret(Thing turret)
+        {
+            return turret?.Faction == Faction.OfPlayer && GetTurretVerb(turret) != null;
+        }
+
+        public bool ShouldTurretAvoidFriendlyFire(Thing turret)
+        {
+            if (!Main.Instance.ShouldEnableTurretControl())
+                return false;
+
+            if (!CanTrackTurret(turret))
+                return false;
+
+            if (!GetExtendedDataFor(turret).AvoidFriendlyFire)
+                return false;
+
+            if (!FireConeOverlay.HasValidWeapon(GetTurretVerb(turret)))
+                return false;
+
+            return true;
+        }
+
         public void DeleteExtendedDataFor(Pawn pawn)
         {
             _store.Remove(pawn.thingIDNumber);
+        }
+
+        public static Verb GetTurretVerb(Thing turret)
+        {
+            if (turret is Building_TurretGun buildingTurret)
+                return buildingTurret.AttackVerb;
+
+            return turret?.TryGetComp<CompTurretGun>()?.AttackVerb;
         }
 
         public ExtendedDataStorage(World world) : base(world)

--- a/src/AvoidFriendlyFire/Custom Storage/ExtendedTurretData.cs
+++ b/src/AvoidFriendlyFire/Custom Storage/ExtendedTurretData.cs
@@ -1,0 +1,14 @@
+﻿using Verse;
+
+namespace AvoidFriendlyFire
+{
+    public class ExtendedTurretData : IExposable
+    {
+        public bool AvoidFriendlyFire = true;
+
+        public void ExposeData()
+        {
+            Scribe_Values.Look(ref AvoidFriendlyFire, "AvoidFriendlyFire", false);
+        }
+    }
+}

--- a/src/AvoidFriendlyFire/FireConeOverlay.cs
+++ b/src/AvoidFriendlyFire/FireConeOverlay.cs
@@ -131,7 +131,12 @@ namespace AvoidFriendlyFire
 
         public static bool HasValidWeapon(Pawn pawn)
         {
-            var primaryWeaponVerb = FireProperties.GetEquippedWeaponVerb(pawn);
+            return HasValidWeapon(FireProperties.GetEquippedWeaponVerb(pawn));
+        }
+
+        public static bool HasValidWeapon(Verb weaponVerb)
+        {
+            var primaryWeaponVerb = weaponVerb;
 
             if (primaryWeaponVerb?.verbProps?.defaultProjectile?.projectile == null)
                 return false;

--- a/src/AvoidFriendlyFire/FireManager.cs
+++ b/src/AvoidFriendlyFire/FireManager.cs
@@ -35,7 +35,8 @@ namespace AvoidFriendlyFire
                 return true;
             }
 
-            Main.Instance.PawnStatusTracker.Remove(fireProperties.Caster);
+            if (fireProperties.CasterPawn != null)
+                Main.Instance.PawnStatusTracker.Remove(fireProperties.CasterPawn);
 
             EnsurePerTickCacheFresh();
 
@@ -52,7 +53,8 @@ namespace AvoidFriendlyFire
                         !blockerPawn.Dead &&
                         blockerPawn.Map == casterMap)
                     {
-                        Main.Instance.PawnStatusTracker.AddBlockedShooter(fireProperties.Caster, blockerPawn);
+                        if (fireProperties.CasterPawn != null)
+                            Main.Instance.PawnStatusTracker.AddBlockedShooter(fireProperties.CasterPawn, blockerPawn);
                     }
                 }
 
@@ -81,7 +83,8 @@ namespace AvoidFriendlyFire
                     return true;
                 }
 
-                Main.Instance.PawnStatusTracker.AddBlockedShooter(fireProperties.Caster, capsuleBlockingPawn);
+                if (fireProperties.CasterPawn != null)
+                    Main.Instance.PawnStatusTracker.AddBlockedShooter(fireProperties.CasterPawn, capsuleBlockingPawn);
                 _perTickSafeShotCache[perTickSafetyKey] = PerTickSafetyResult.Unsafe(capsuleBlockingPawn);
                 return false;
             }
@@ -129,7 +132,7 @@ namespace AvoidFriendlyFire
             var cellIndices = casterMap.cellIndices;
             var originCell = fireProperties.Origin;
             var targetCell = fireProperties.Target;
-            var shooterPawn = fireProperties.Caster;
+            var shooterPawn = fireProperties.CasterPawn;
 
             for (int pawnIndex = 0; pawnIndex < _relevantPawnsCache.Count; pawnIndex++)
             {
@@ -144,7 +147,8 @@ namespace AvoidFriendlyFire
                 if (!fireCone.Contains(candidateCellIndex))
                     continue;
 
-                Main.Instance.PawnStatusTracker.AddBlockedShooter(shooterPawn, candidatePawn);
+                if (shooterPawn != null)
+                    Main.Instance.PawnStatusTracker.AddBlockedShooter(shooterPawn, candidatePawn);
                 _perTickSafeShotCache[perTickSafetyKey] = PerTickSafetyResult.Unsafe(candidatePawn);
                 return false;
             }
@@ -166,7 +170,7 @@ namespace AvoidFriendlyFire
             if (relevantPawns.Count == 0)
                 return null;
 
-            var shooterPawn = fireProperties.Caster;
+            var shooterPawn = fireProperties.CasterPawn;
             var originCell = fireProperties.Origin;
             var targetCell = fireProperties.Target;
 
@@ -263,17 +267,16 @@ namespace AvoidFriendlyFire
 
         private static PerTickSafetyKey CreatePerTickSafetyKey(FireProperties fireProperties)
         {
-            var pawn = fireProperties.Caster;
+            var caster = fireProperties.Caster;
             var map = fireProperties.CasterMap;
-            var shooterPositionIndex = map.cellIndices.CellToIndex(pawn.Position);
-            var primaryWeaponId = pawn.equipment?.Primary?.thingIDNumber ?? 0;
+            var shooterPositionIndex = map.cellIndices.CellToIndex(caster.Position);
 
             return new PerTickSafetyKey(
                 map.uniqueID,
-                pawn.thingIDNumber,
+                caster.thingIDNumber,
                 shooterPositionIndex,
                 fireProperties.TargetIndex,
-                primaryWeaponId);
+                fireProperties.WeaponSourceId);
         }
 
         private readonly struct PerTickSafetyResult

--- a/src/AvoidFriendlyFire/FireProperties.cs
+++ b/src/AvoidFriendlyFire/FireProperties.cs
@@ -40,15 +40,24 @@ namespace AvoidFriendlyFire
 
         public int TargetIndex => CasterMap.cellIndices.CellToIndex(Target);
 
-        public Pawn Caster { get; }
+        public Thing Caster { get; }
+
+        public Pawn CasterPawn => Caster as Pawn;
+
+        public int WeaponSourceId => _weaponVerb?.EquipmentSource?.thingIDNumber ?? 0;
 
         private readonly Verb _weaponVerb;
 
         public FireProperties(Pawn caster, IntVec3 target)
+            : this((Thing)caster, GetEquippedWeaponVerb(caster), target)
+        {
+        }
+
+        public FireProperties(Thing caster, Verb weaponVerb, IntVec3 target)
         {
             Target = target;
             Caster = caster;
-            _weaponVerb = GetEquippedWeaponVerb(caster);
+            _weaponVerb = weaponVerb;
             Origin = Caster.Position;
         }
 
@@ -87,7 +96,10 @@ namespace AvoidFriendlyFire
         {
             var distance = (Target - Origin).LengthHorizontal;
 
-            var factorFromShooterAndDist = ShotReport.HitFactorFromShooter(Caster, distance);
+            if (CasterPawn == null)
+                return 0f;
+
+            var factorFromShooterAndDist = ShotReport.HitFactorFromShooter(CasterPawn, distance);
 
             var factorFromEquipment = _weaponVerb.verbProps.GetHitChanceFactor(
                 _weaponVerb.EquipmentSource, distance);
@@ -121,6 +133,9 @@ namespace AvoidFriendlyFire
             var adjustedMissRadius = CalculateAdjustedForcedMiss();
             if (adjustedMissRadius > 0.5f)
                 return ForcedMissRadius;
+
+            if (CasterPawn == null)
+                return 2f;
 
             if (!Main.Instance.ShouldEnableAccurateMissRadius())
                 return 2f;
@@ -164,6 +179,9 @@ namespace AvoidFriendlyFire
                 int forcedMissRingCount = forcedMissOuterCount - forcedMissInnerCount;
                 return new MissAreaDescriptor(GenRadial.RadialPattern, forcedMissInnerCount, forcedMissRingCount);
             }
+
+            if (CasterPawn == null)
+                return new MissAreaDescriptor(GenAdj.AdjacentCells, 8);
 
             if (!Main.Instance.ShouldEnableAccurateMissRadius())
             {

--- a/src/AvoidFriendlyFire/Main.cs
+++ b/src/AvoidFriendlyFire/Main.cs
@@ -16,6 +16,7 @@ namespace AvoidFriendlyFire
         public bool ProtectColonyAnimals;
         public bool IgnoreShieldedPawns = true;
         public bool EnableWhenUndrafted;
+        public bool EnableTurretControl;
         public bool EnableAccurateMissRadius = true;
         public bool UseFarSideFilter = true;
         public bool UseCapsuleOnlyCheck;
@@ -32,6 +33,7 @@ namespace AvoidFriendlyFire
             Scribe_Values.Look(ref ProtectColonyAnimals, "protectColonyAnimals");
             Scribe_Values.Look(ref IgnoreShieldedPawns, "ignoreShieldedPawns", true);
             Scribe_Values.Look(ref EnableWhenUndrafted, "enableWhenUndrafted");
+            Scribe_Values.Look(ref EnableTurretControl, "enableTurretControl");
             Scribe_Values.Look(ref EnableAccurateMissRadius, "enableAccurateMissRadius", true);
             Scribe_Values.Look(ref UseFarSideFilter, "useFarSideFilter", true);
             Scribe_Values.Look(ref UseCapsuleOnlyCheck, "useCapsuleOnlyCheck", false);
@@ -91,6 +93,8 @@ namespace AvoidFriendlyFire
                 "FALCFF.IgnoreShieldedPawnsDesc".Translate());
             listing.CheckboxLabeled("FALCFF.EnableWhenUndrafted".Translate(), ref _settings.EnableWhenUndrafted,
                 "FALCFF.EnableWhenUndraftedDesc".Translate());
+            listing.CheckboxLabeled("FALCFF.EnableTurretControl".Translate(), ref _settings.EnableTurretControl,
+                "FALCFF.EnableTurretControlDesc".Translate());
             listing.CheckboxLabeled("FALCFF.EnableAccurateMissRadius".Translate(),
                 ref _settings.EnableAccurateMissRadius, "FALCFF.EnableAccurateMissRadiusDesc".Translate());
             listing.CheckboxLabeled("FALCFF.UseFarSideFilter".Translate(), ref _settings.UseFarSideFilter,
@@ -220,6 +224,11 @@ namespace AvoidFriendlyFire
         public bool ShouldEnableWhenUndrafted()
         {
             return _settings.EnableWhenUndrafted;
+        }
+
+        public bool ShouldEnableTurretControl()
+        {
+            return _settings.EnableTurretControl;
         }
 
         public bool ShouldEnableAccurateMissRadius()

--- a/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
@@ -19,12 +19,24 @@ namespace AvoidFriendlyFire
             if (validator != null)
                 return true;
 
-            var shooter = searcher.Thing as Pawn;
-            if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(shooter))
+            var shooterThing = searcher.Thing;
+            if (shooterThing is Pawn shooterPawn)
+            {
+                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(shooterPawn))
+                    return true;
+
+                var shooterVerb = FireProperties.GetEquippedWeaponVerb(shooterPawn);
+                validator = target => Main.Instance.GetFireManager().CanHitTargetSafely(
+                    new FireProperties(shooterPawn, shooterVerb, target.Position));
+                return true;
+            }
+
+            if (!Main.Instance.GetExtendedDataStorage().ShouldTurretAvoidFriendlyFire(shooterThing))
                 return true;
 
+            var turretVerb = ExtendedDataStorage.GetTurretVerb(shooterThing);
             validator = target => Main.Instance.GetFireManager().CanHitTargetSafely(
-                new FireProperties(shooter, target.Position));
+                new FireProperties(shooterThing, turretVerb, target.Position));
 
             return true;
             }

--- a/src/AvoidFriendlyFire/Patches/Building_TurretGun_GetGizmos_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/Building_TurretGun_GetGizmos_Patch.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace AvoidFriendlyFire
+{
+    [HarmonyPatch(typeof(Building_TurretGun), "GetGizmos")]
+    public class Building_TurretGun_GetGizmos_Patch
+    {
+        public static void Postfix(ref IEnumerable<Gizmo> __result, Building_TurretGun __instance)
+        {
+            if (!Main.Instance.IsModEnabled() || !Main.Instance.ShouldEnableTurretControl())
+                return;
+
+            if (__result == null || !__result.Any())
+                return;
+
+            var extendedDataStore = Main.Instance.GetExtendedDataStorage();
+            if (!extendedDataStore.CanTrackTurret(__instance))
+                return;
+
+            if (!FireConeOverlay.HasValidWeapon(__instance.AttackVerb))
+                return;
+
+            var turretData = extendedDataStore.GetExtendedDataFor(__instance);
+            var gizmoList = __result.ToList();
+            gizmoList.Add(new Command_Toggle
+            {
+                defaultLabel = "FALCFF.AvoidFriendlyFireTurret".Translate(),
+                defaultDesc = "FALCFF.AvoidFriendlyFireTurretDesc".Translate(),
+                icon = Resources.FriendlyFireIcon,
+                isActive = () => turretData.AvoidFriendlyFire,
+                toggleAction = () => turretData.AvoidFriendlyFire = !turretData.AvoidFriendlyFire
+            });
+            __result = gizmoList;
+        }
+    }
+}

--- a/src/AvoidFriendlyFire/Patches/Building_TurretGun_OrderAttack_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/Building_TurretGun_OrderAttack_Patch.cs
@@ -1,0 +1,30 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace AvoidFriendlyFire
+{
+    [HarmonyPatch(typeof(Building_TurretGun), "OrderAttack")]
+    public class Building_TurretGun_OrderAttack_Patch
+    {
+        public static bool Prefix(Building_TurretGun __instance, LocalTargetInfo targ)
+        {
+            if (!Main.Instance.IsModEnabled())
+                return true;
+
+            if (!targ.IsValid || rootDistanceTooShort(__instance.Position, targ.Cell))
+                return true;
+
+            if (!Main.Instance.GetExtendedDataStorage().ShouldTurretAvoidFriendlyFire(__instance))
+                return true;
+
+            return Main.Instance.GetFireManager().CanHitTargetSafely(
+                new FireProperties(__instance, __instance.AttackVerb, targ.Cell));
+        }
+
+        private static bool rootDistanceTooShort(IntVec3 root, IntVec3 target)
+        {
+            return root.DistanceTo(target) <= 2f;
+        }
+    }
+}

--- a/src/AvoidFriendlyFire/Patches/Building_TurretGun_TryFindNewTarget_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/Building_TurretGun_TryFindNewTarget_Patch.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace AvoidFriendlyFire
+{
+    [HarmonyPatch(typeof(Building_TurretGun), "TryFindNewTarget")]
+    public class Building_TurretGun_TryFindNewTarget_Patch
+    {
+        public static void Postfix(Building_TurretGun __instance, ref LocalTargetInfo __result)
+        {
+            if (!Main.Instance.IsModEnabled())
+                return;
+
+            if (!__result.IsValid)
+                return;
+
+            if (!Main.Instance.GetExtendedDataStorage().ShouldTurretAvoidFriendlyFire(__instance))
+                return;
+
+            if (__instance.Position.DistanceTo(__result.Cell) <= 2f)
+                return;
+
+            if (Main.Instance.GetFireManager().CanHitTargetSafely(
+                new FireProperties(__instance, __instance.AttackVerb, __result.Cell)))
+            {
+                return;
+            }
+
+            __result = LocalTargetInfo.Invalid;
+        }
+    }
+}

--- a/src/AvoidFriendlyFire/Patches/CompTurretGun_CompGetGizmosExtra_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/CompTurretGun_CompGetGizmosExtra_Patch.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace AvoidFriendlyFire
+{
+    [HarmonyPatch(typeof(CompTurretGun), "CompGetGizmosExtra")]
+    public class CompTurretGun_CompGetGizmosExtra_Patch
+    {
+        public static void Postfix(ref IEnumerable<Gizmo> __result, CompTurretGun __instance)
+        {
+            if (!Main.Instance.IsModEnabled() || !Main.Instance.ShouldEnableTurretControl())
+                return;
+
+            if (__result == null || !__result.Any())
+                return;
+
+            var turretThing = __instance.parent;
+            var extendedDataStore = Main.Instance.GetExtendedDataStorage();
+            if (!extendedDataStore.CanTrackTurret(turretThing))
+                return;
+
+            if (!FireConeOverlay.HasValidWeapon(__instance.AttackVerb))
+                return;
+
+            var turretData = extendedDataStore.GetExtendedDataFor(turretThing);
+            var gizmoList = __result.ToList();
+            gizmoList.Add(new Command_Toggle
+            {
+                defaultLabel = "FALCFF.AvoidFriendlyFireTurret".Translate(),
+                defaultDesc = "FALCFF.AvoidFriendlyFireTurretDesc".Translate(),
+                icon = Resources.FriendlyFireIcon,
+                isActive = () => turretData.AvoidFriendlyFire,
+                toggleAction = () => turretData.AvoidFriendlyFire = !turretData.AvoidFriendlyFire
+            });
+            __result = gizmoList;
+        }
+    }
+}

--- a/src/AvoidFriendlyFire/Patches/Verb_CanHitTargetFrom_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/Verb_CanHitTargetFrom_Patch.cs
@@ -15,7 +15,7 @@ namespace AvoidFriendlyFire
             if (!Main.Instance.IsModEnabled())
                 return;
 
-            if (!__result || !__instance.CasterIsPawn || !targ.IsValid)
+            if (!__result || !targ.IsValid)
                 return;
 
             if (targ.Thing != null && targ.Thing == __instance.caster)
@@ -24,12 +24,24 @@ namespace AvoidFriendlyFire
             if (root.DistanceTo(targ.Cell) <= 2f)
                 return;
 
-            var pawn = __instance.CasterPawn;
-            if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(pawn))
+            if (__instance.caster is Pawn pawn)
+            {
+                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(pawn))
+                    return;
+
+                __result = Main.Instance.GetFireManager().CanHitTargetSafely(
+                    new FireProperties(pawn, __instance, targ.Cell));
+                return;
+            }
+
+            if (!(__instance.caster is Thing casterThing))
+                return;
+
+            if (!Main.Instance.GetExtendedDataStorage().ShouldTurretAvoidFriendlyFire(casterThing))
                 return;
 
             __result = Main.Instance.GetFireManager().CanHitTargetSafely(
-                new FireProperties(pawn, targ.Cell));
+                new FireProperties(casterThing, __instance, targ.Cell));
             }
             finally
             {


### PR DESCRIPTION
## Summary
- add optional turret friendly-fire control behind a new global mod setting that defaults to off
- when turret control is enabled, give each player turret its own Avoid Friendly Fire gizmo that defaults to on the first time the turret is seen

## Root Cause
- the mod only handled pawn shooters, with pawn-only storage, pawn-only gizmos, and safety checks that assumed a pawn caster

## Changes
- add persistent per-turret state alongside the existing pawn state
- add a global mod setting for turret control and turret gizmos on Building_TurretGun and CompTurretGun
- extend the safety pipeline so turret target selection, forced attacks, and shot validation can reuse the existing fire-cone checks
- add language keys for the new turret option and turret gizmo text

## Verification
- dotnet build src/AvoidFriendlyFire/1.6.csproj

## Notes
- build completed with existing NU1900 warnings because sandboxed restore could not reach NuGet vulnerability data

Fixes #3