### PR TITLE
Fix #5: Add full IFF support for mechanitor mechs with opt-in firing control and protection toggles

### DIFF
--- a/Languages/ChineseSimplified/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/ChineseSimplified/Keyed/FALCFF_LanguageData.xml
@@ -12,6 +12,9 @@
   <FALCFF.ProtectColonyAnimals>保护所有的宠物</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>如果关闭，则只有经过了主人训练的动物才成为保护对象。选中此选项后，属于殖民地的所有宠物/家畜动物都将成为保护对象。但是在拥有多个家畜的低性能电脑上可能会出现性能问题。</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>忽略带有护盾的殖民者</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>在至少有10%的能量下，射击者不会担心佩带护盾的殖民者在射击路径上。</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -20,6 +23,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/Languages/ChineseTraditional/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/ChineseTraditional/Keyed/FALCFF_LanguageData.xml
@@ -12,6 +12,9 @@
   <FALCFF.ProtectColonyAnimals>保護所有的寵物</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>如果關閉，則只有經過了主人訓練的動物才成爲保護對象。選中此選項後，屬于殖民地的所有寵物/家畜動物都將成爲保護對象。但是在擁有多個家畜的低性能電腦上可能會出現性能問題。</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>忽略帶有護盾的殖民者</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>在至少有10%的能量下，射擊者不會擔心佩帶護盾的殖民者在射擊路徑上。</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -20,6 +23,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/Languages/English/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/English/Keyed/FALCFF_LanguageData.xml
@@ -12,6 +12,9 @@
   <FALCFF.ProtectColonyAnimals>Protect All Tame Animals</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>Protect all tame animals belonging to the colony. May cause performance issues on lower end machines with large numbers of livestock.</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>Ignore pawns with active shield belts</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>Shooters will not worry about pawns wearing a shield belt with at least 10% power standing in the line of fire.</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -20,6 +23,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/Languages/Japanese/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/Japanese/Keyed/FALCFF_LanguageData.xml
@@ -13,6 +13,9 @@
   <FALCFF.ProtectColonyAnimals>すべてのペットを保護</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>オフにすると、主人を持つ訓練をされた動物だけが保護対象になります。オンにすると、コロニーに所属するすべてのペット/家畜動物が保護対象になります。ただし、多数の家畜がいる低スペックPCマシンではパフォーマンスの問題が発生する可能性があります。</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>シールドベルトを装備中のポーンを保護</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>射撃手は、射線上に少なくとも10％のシールドが残っているシールドベルトを装着したポーンについて心配する必要はありません。</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -21,6 +24,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/Languages/Spanish/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/Spanish/Keyed/FALCFF_LanguageData.xml
@@ -12,6 +12,9 @@
   <FALCFF.ProtectColonyAnimals>Proteger a todos los animales domesticados</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>Proteger a todos los animales domesticados de la colonia. Puede causar problemas de rendimiento en máquinas de gama baja con gran cantidad de ganado.</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>Ignorar colonos con un cinturón de protección activo</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>Los tiradores no se preocuparán de que los peones usen un cinturón de protección con al menos un 10% de potencia dentro de la línea de tiro.</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -20,6 +23,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/Languages/SpanishLatin/Keyed/FALCFF_LanguageData.xml
+++ b/Languages/SpanishLatin/Keyed/FALCFF_LanguageData.xml
@@ -12,6 +12,9 @@
   <FALCFF.ProtectColonyAnimals>Proteger a todos los animales domesticados</FALCFF.ProtectColonyAnimals>
   <FALCFF.ProtectColonyAnimalsDesc>Proteger a todos los animales domesticados de la colonia. Puede causar problemas de rendimiento en máquinas de gama baja con gran cantidad de ganado.</FALCFF.ProtectColonyAnimalsDesc>
 
+  <FALCFF.ProtectPlayerMechs>Protect Player Mechs</FALCFF.ProtectPlayerMechs>
+  <FALCFF.ProtectPlayerMechsDesc>Always protect player-controlled mechanitor mechs from friendly fire checks, even when animal protection is disabled.</FALCFF.ProtectPlayerMechsDesc>
+
   <FALCFF.IgnoreShieldedPawns>Ignorar colonos con un cinturón de protección activo</FALCFF.IgnoreShieldedPawns>
   <FALCFF.IgnoreShieldedPawnsDesc>Los tiradores no se preocuparán de que los peones usen un cinturón de protección con al menos un 10% de potencia dentro de la línea de tiro.</FALCFF.IgnoreShieldedPawnsDesc>
 
@@ -20,6 +23,9 @@
 
   <FALCFF.EnableTurretControl>Enable turret control</FALCFF.EnableTurretControl>
   <FALCFF.EnableTurretControlDesc>Allow Avoid Friendly Fire to control player turrets. This is off by default. When enabled, each turret gets its own toggle gizmo.</FALCFF.EnableTurretControlDesc>
+
+  <FALCFF.EnableMechControl>Enable mech control</FALCFF.EnableMechControl>
+  <FALCFF.EnableMechControlDesc>Allow Avoid Friendly Fire to control player mechs. This is off by default. When enabled, each mech gets its own toggle gizmo and uses its built-in attack verb for safety checks.</FALCFF.EnableMechControlDesc>
 
   <FALCFF.AvoidFriendlyFireTurret>Avoid Friendly Fire</FALCFF.AvoidFriendlyFireTurret>
   <FALCFF.AvoidFriendlyFireTurretDesc>Prevents this turret from firing when a friendly pawn could be hit by its shot.</FALCFF.AvoidFriendlyFireTurretDesc>

--- a/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
+++ b/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
@@ -54,7 +54,13 @@ namespace AvoidFriendlyFire
 
         public bool CanTrackPawn(Pawn pawn)
         {
-            return pawn?.Faction != null && pawn.Faction == Faction.OfPlayer;
+            if (pawn?.Faction != Faction.OfPlayer)
+                return false;
+
+            if (pawn.IsColonyMechPlayerControlled && !Main.Instance.ShouldEnableMechControl())
+                return false;
+
+            return true;
         }
 
         public bool ShouldPawnAvoidFriendlyFire(Pawn pawn)

--- a/src/AvoidFriendlyFire/FireConeOverlay.cs
+++ b/src/AvoidFriendlyFire/FireConeOverlay.cs
@@ -125,13 +125,13 @@ namespace AvoidFriendlyFire
 
         public static float GetEquippedWeaponRange(Pawn pawn)
         {
-            var primaryWeaponVerb = FireProperties.GetEquippedWeaponVerb(pawn);
+            var primaryWeaponVerb = FireProperties.GetRangedAttackVerb(pawn);
             return primaryWeaponVerb?.verbProps.range ?? 0;
         }
 
         public static bool HasValidWeapon(Pawn pawn)
         {
-            return HasValidWeapon(FireProperties.GetEquippedWeaponVerb(pawn));
+            return HasValidWeapon(FireProperties.GetRangedAttackVerb(pawn));
         }
 
         public static bool HasValidWeapon(Verb weaponVerb)

--- a/src/AvoidFriendlyFire/FireManager.cs
+++ b/src/AvoidFriendlyFire/FireManager.cs
@@ -217,7 +217,10 @@ namespace AvoidFriendlyFire
                 if (candidateFaction == null)
                     continue;
 
-                if (candidatePawn.RaceProps.Humanlike)
+                if (candidatePawn.IsColonyMechPlayerControlled && Main.Instance.ShouldProtectPlayerMechs())
+                {
+                }
+                else if (candidatePawn.RaceProps.Humanlike)
                 {
                     if (candidatePawn.IsPrisoner || candidatePawn.HostileTo(Faction.OfPlayer))
                         continue;

--- a/src/AvoidFriendlyFire/FireProperties.cs
+++ b/src/AvoidFriendlyFire/FireProperties.cs
@@ -49,7 +49,7 @@ namespace AvoidFriendlyFire
         private readonly Verb _weaponVerb;
 
         public FireProperties(Pawn caster, IntVec3 target)
-            : this((Thing)caster, GetEquippedWeaponVerb(caster), target)
+            : this((Thing)caster, GetRangedAttackVerb(caster), target)
         {
         }
 
@@ -216,8 +216,19 @@ namespace AvoidFriendlyFire
                 : VerbUtility.CalculateAdjustedForcedMiss(ForcedMissRadius, Target - Origin);
         }
 
-        public static Verb GetEquippedWeaponVerb(Pawn pawn)
+        public static Verb GetRangedAttackVerb(Pawn pawn)
         {
+            if (pawn == null)
+                return null;
+
+            if (pawn.IsColonyMechPlayerControlled)
+            {
+                if (!Main.Instance.ShouldEnableMechControl())
+                    return null;
+
+                return pawn.TryGetAttackVerb(null, false);
+            }
+
             return pawn.equipment?.PrimaryEq?.PrimaryVerb;
         }
     }

--- a/src/AvoidFriendlyFire/Main.cs
+++ b/src/AvoidFriendlyFire/Main.cs
@@ -14,9 +14,11 @@ namespace AvoidFriendlyFire
         public bool OverlayShowCapsule;
         public bool ProtectPets = true;
         public bool ProtectColonyAnimals;
+        public bool ProtectPlayerMechs;
         public bool IgnoreShieldedPawns = true;
         public bool EnableWhenUndrafted;
         public bool EnableTurretControl;
+        public bool EnableMechControl;
         public bool EnableAccurateMissRadius = true;
         public bool UseFarSideFilter = true;
         public bool UseCapsuleOnlyCheck;
@@ -31,9 +33,11 @@ namespace AvoidFriendlyFire
             Scribe_Values.Look(ref OverlayShowCapsule, "overlayShowCapsule", false);
             Scribe_Values.Look(ref ProtectPets, "protectPets", true);
             Scribe_Values.Look(ref ProtectColonyAnimals, "protectColonyAnimals");
+            Scribe_Values.Look(ref ProtectPlayerMechs, "protectPlayerMechs");
             Scribe_Values.Look(ref IgnoreShieldedPawns, "ignoreShieldedPawns", true);
             Scribe_Values.Look(ref EnableWhenUndrafted, "enableWhenUndrafted");
             Scribe_Values.Look(ref EnableTurretControl, "enableTurretControl");
+            Scribe_Values.Look(ref EnableMechControl, "enableMechControl");
             Scribe_Values.Look(ref EnableAccurateMissRadius, "enableAccurateMissRadius", true);
             Scribe_Values.Look(ref UseFarSideFilter, "useFarSideFilter", true);
             Scribe_Values.Look(ref UseCapsuleOnlyCheck, "useCapsuleOnlyCheck", false);
@@ -89,12 +93,16 @@ namespace AvoidFriendlyFire
                 "FALCFF.ProtectPetsDesc".Translate());
             listing.CheckboxLabeled("FALCFF.ProtectColonyAnimals".Translate(), ref _settings.ProtectColonyAnimals,
                 "FALCFF.ProtectColonyAnimalsDesc".Translate());
+            listing.CheckboxLabeled("FALCFF.ProtectPlayerMechs".Translate(), ref _settings.ProtectPlayerMechs,
+                "FALCFF.ProtectPlayerMechsDesc".Translate());
             listing.CheckboxLabeled("FALCFF.IgnoreShieldedPawns".Translate(), ref _settings.IgnoreShieldedPawns,
                 "FALCFF.IgnoreShieldedPawnsDesc".Translate());
             listing.CheckboxLabeled("FALCFF.EnableWhenUndrafted".Translate(), ref _settings.EnableWhenUndrafted,
                 "FALCFF.EnableWhenUndraftedDesc".Translate());
             listing.CheckboxLabeled("FALCFF.EnableTurretControl".Translate(), ref _settings.EnableTurretControl,
                 "FALCFF.EnableTurretControlDesc".Translate());
+            listing.CheckboxLabeled("FALCFF.EnableMechControl".Translate(), ref _settings.EnableMechControl,
+                "FALCFF.EnableMechControlDesc".Translate());
             listing.CheckboxLabeled("FALCFF.EnableAccurateMissRadius".Translate(),
                 ref _settings.EnableAccurateMissRadius, "FALCFF.EnableAccurateMissRadiusDesc".Translate());
             listing.CheckboxLabeled("FALCFF.UseFarSideFilter".Translate(), ref _settings.UseFarSideFilter,
@@ -216,6 +224,11 @@ namespace AvoidFriendlyFire
             return _settings.ProtectColonyAnimals;
         }
 
+        public bool ShouldProtectPlayerMechs()
+        {
+            return _settings.ProtectPlayerMechs;
+        }
+
         public bool ShouldIgnoreShieldedPawns()
         {
             return _settings.IgnoreShieldedPawns;
@@ -229,6 +242,11 @@ namespace AvoidFriendlyFire
         public bool ShouldEnableTurretControl()
         {
             return _settings.EnableTurretControl;
+        }
+
+        public bool ShouldEnableMechControl()
+        {
+            return _settings.EnableMechControl;
         }
 
         public bool ShouldEnableAccurateMissRadius()

--- a/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
@@ -25,7 +25,7 @@ namespace AvoidFriendlyFire
                 if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(shooterPawn))
                     return true;
 
-                var shooterVerb = FireProperties.GetEquippedWeaponVerb(shooterPawn);
+                var shooterVerb = FireProperties.GetRangedAttackVerb(shooterPawn);
                 validator = target => Main.Instance.GetFireManager().CanHitTargetSafely(
                     new FireProperties(shooterPawn, shooterVerb, target.Position));
                 return true;


### PR DESCRIPTION
## Summary
- adds opt-in Avoid Friendly Fire control for player-controlled mechanitor mechs
- adds a separate opt-in mech protection setting so player mechs can be treated as friendly-fire blockers even when animal protection is off

## Root Cause
- mech shooters were only discovered through pawn equipment verbs, and the protected-pawn cache only had dedicated paths for humanlikes and colony animals

## Changes
- adds `Enable mech control` and `Protect Player Mechs` settings, both defaulting to off
- resolves mech firing verbs through the pawn attack verb path so enabled player mechs participate in the same safety checks and gizmo flow as other supported shooters
- includes player mechs in the relevant pawn cache when mech protection is enabled, without changing existing pawn, pet, colony-animal, or turret behavior by default
- adds language keys for the new settings in the existing localization files

## Verification
- `dotnet build src/AvoidFriendlyFire/1.6.csproj`

Fixes #5
