### PR TITLE
Fix #7: Crashes

### DIFF
--- a/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
+++ b/src/AvoidFriendlyFire/Custom Storage/ExtendedDataStorage.cs
@@ -65,13 +65,18 @@ namespace AvoidFriendlyFire
 
         public bool ShouldPawnAvoidFriendlyFire(Pawn pawn)
         {
+            return ShouldPawnAvoidFriendlyFire(pawn, FireProperties.GetRangedAttackVerb(pawn));
+        }
+
+        public bool ShouldPawnAvoidFriendlyFire(Pawn pawn, Verb weaponVerb)
+        {
             if (!CanTrackPawn(pawn))
                 return false;
 
             if (!GetExtendedDataFor(pawn).AvoidFriendlyFire)
                 return false;
 
-            if (!FireConeOverlay.HasValidWeapon(pawn))
+            if (!FireConeOverlay.HasValidWeapon(weaponVerb))
                 return false;
 
             return true;

--- a/src/AvoidFriendlyFire/FireProperties.cs
+++ b/src/AvoidFriendlyFire/FireProperties.cs
@@ -28,6 +28,9 @@ namespace AvoidFriendlyFire
 
     public class FireProperties
     {
+        [ThreadStatic]
+        private static int _suppressDynamicPawnVerbLookupDepth;
+
         public IntVec3 Target;
 
         public Map CasterMap => Caster.Map;
@@ -226,10 +229,27 @@ namespace AvoidFriendlyFire
                 if (!Main.Instance.ShouldEnableMechControl())
                     return null;
 
+                if (_suppressDynamicPawnVerbLookupDepth > 0)
+                    return null;
+
                 return pawn.TryGetAttackVerb(null, false);
             }
 
             return pawn.equipment?.PrimaryEq?.PrimaryVerb;
+        }
+
+        public static IDisposable SuppressDynamicPawnVerbLookup()
+        {
+            _suppressDynamicPawnVerbLookupDepth++;
+            return new DynamicPawnVerbLookupSuppressionScope();
+        }
+
+        private sealed class DynamicPawnVerbLookupSuppressionScope : IDisposable
+        {
+            public void Dispose()
+            {
+                _suppressDynamicPawnVerbLookupDepth--;
+            }
         }
     }
 }

--- a/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/AttackTargetFinder_BestAttackTarget_Patch.cs
@@ -22,10 +22,10 @@ namespace AvoidFriendlyFire
             var shooterThing = searcher.Thing;
             if (shooterThing is Pawn shooterPawn)
             {
-                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(shooterPawn))
+                var shooterVerb = FireProperties.GetRangedAttackVerb(shooterPawn);
+                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(shooterPawn, shooterVerb))
                     return true;
 
-                var shooterVerb = FireProperties.GetRangedAttackVerb(shooterPawn);
                 validator = target => Main.Instance.GetFireManager().CanHitTargetSafely(
                     new FireProperties(shooterPawn, shooterVerb, target.Position));
                 return true;

--- a/src/AvoidFriendlyFire/Patches/Verb_CanHitTargetFrom_Patch.cs
+++ b/src/AvoidFriendlyFire/Patches/Verb_CanHitTargetFrom_Patch.cs
@@ -12,6 +12,8 @@ namespace AvoidFriendlyFire
             var scope = PerfMetrics.Measure(PerfSection.Patch_Verb_CanHitTargetFrom);
             try
             {
+            using (FireProperties.SuppressDynamicPawnVerbLookup())
+            {
             if (!Main.Instance.IsModEnabled())
                 return;
 
@@ -26,7 +28,7 @@ namespace AvoidFriendlyFire
 
             if (__instance.caster is Pawn pawn)
             {
-                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(pawn))
+                if (!Main.Instance.GetExtendedDataStorage().ShouldPawnAvoidFriendlyFire(pawn, __instance))
                     return;
 
                 __result = Main.Instance.GetFireManager().CanHitTargetSafely(
@@ -42,6 +44,7 @@ namespace AvoidFriendlyFire
 
             __result = Main.Instance.GetFireManager().CanHitTargetSafely(
                 new FireProperties(casterThing, __instance, targ.Cell));
+            }
             }
             finally
             {


### PR DESCRIPTION
## Summary
- fix the stack overflow crash that can occur a few seconds after unpausing with Avoid Friendly Fire enabled
- keep mech friendly-fire control working by using the active verb in runtime safety checks instead of recursively resolving a new attack verb

## Root Cause
- the v1.6.7 mech support path called `pawn.TryGetAttackVerb()` while handling the `Verb.CanHitTargetFrom` postfix, which could recurse through MVCF/VEF verb selection until the game overflowed the stack

## Changes
- add a verb-aware `ShouldPawnAvoidFriendlyFire` overload so runtime checks can validate the current verb without re-querying the pawn
- suppress dynamic mech verb lookup while the `CanHitTargetFrom` patch is running, preventing re-entrant `TryGetAttackVerb` calls from recursing back into the same Harmony path
- reuse the resolved shooter verb in `AttackTargetFinder_BestAttackTarget_Patch` instead of resolving it twice

## Verification
- `dotnet build src/AvoidFriendlyFire/1.6.csproj`

## Notes
- I did not run an in-game RimWorld reproduction in this environment, so gameplay verification still depends on testing with a mech-enabled mod stack

Fixes #7
