### PR TITLE
Fix #9: Build assembly as AvoidFriendlyFire.dll

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 1. (Optional) Clone this repository into your `RimWorld/Mods` directory.  
 2. Open `src/AvoidFriendlyFire/AvoidFriendlyFire.sln` in Visual Studio 2022.  
-3. Build `1.6.csproj` to produce `1.6.dll` and `1.6.pdb`.  
+3. Build `1.6.csproj` to produce `AvoidFriendlyFire.dll` and `AvoidFriendlyFire.pdb`.
 4. Copy the output into `1.6/Assemblies` within the mod folder.
 
 ## License

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -196,7 +196,7 @@ fi
 
 git -C "${repo_root}" tag "${tag_name}"
 
-"${rsync_script}" "${temp_root}" "${mod_name}"
+"${rsync_script}" "${temp_root}/Mods" "${mod_name}"
 (cd "${temp_root}/Mods" && zip -rq "${archive_path}" "${mod_name}")
 
 echo "Created release archive ${archive_path}"

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -90,16 +90,9 @@ fi
 
 assembly_dir="${repo_root}/1.6/Assemblies"
 assembly_dll="${assembly_dir}/AvoidFriendlyFire.dll"
-assembly_pdb="${assembly_dir}/AvoidFriendlyFire.pdb"
 
 if [[ ! -f "${assembly_dll}" ]]; then
   echo "Missing build artifact ${assembly_dll}" >&2
-  echo "Build the mod before making a release." >&2
-  exit 1
-fi
-
-if [[ ! -f "${assembly_pdb}" ]]; then
-  echo "Missing debug symbols ${assembly_pdb}" >&2
   echo "Build the mod before making a release." >&2
   exit 1
 fi

--- a/scripts/make-release.sh
+++ b/scripts/make-release.sh
@@ -88,8 +88,18 @@ if [[ ! -x "${rsync_script}" ]]; then
   exit 1
 fi
 
-if [[ ! -f "${repo_root}/1.6/Assemblies/1.6.dll" ]]; then
-  echo "Missing build artifact ${repo_root}/1.6/Assemblies/1.6.dll" >&2
+assembly_dir="${repo_root}/1.6/Assemblies"
+assembly_dll="${assembly_dir}/AvoidFriendlyFire.dll"
+assembly_pdb="${assembly_dir}/AvoidFriendlyFire.pdb"
+
+if [[ ! -f "${assembly_dll}" ]]; then
+  echo "Missing build artifact ${assembly_dll}" >&2
+  echo "Build the mod before making a release." >&2
+  exit 1
+fi
+
+if [[ ! -f "${assembly_pdb}" ]]; then
+  echo "Missing debug symbols ${assembly_pdb}" >&2
   echo "Build the mod before making a release." >&2
   exit 1
 fi

--- a/scripts/rsync-to-rimworld-mods.sh
+++ b/scripts/rsync-to-rimworld-mods.sh
@@ -2,13 +2,58 @@
 
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/rsync-to-rimworld-mods.sh RIMWORLD_MODS_DIR [MOD_NAME]
+
+Deploy the mod files into an explicit RimWorld Mods directory.
+
+Examples:
+  scripts/rsync-to-rimworld-mods.sh "$HOME/.steam/steam/steamapps/common/RimWorld/Mods"
+  scripts/rsync-to-rimworld-mods.sh /tmp/release-root/Mods AvoidFriendlyFire
+
+When no destination is provided, this script does not sync files. It checks
+common Steam locations for RimWorld Mods directories and prints suggestions.
+EOF
+}
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 
-default_rimworld_root="/home/christoph/snap/steam/common/.local/share/Steam/steamapps/common/RimWorld"
-rimworld_root="${1:-$default_rimworld_root}"
 mod_name="${2:-AvoidFriendlyFire}"
-destination="${rimworld_root%/}/Mods/${mod_name}"
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+  usage
+  printf '\nNo destination provided; no files were synced.\n' >&2
+  printf '\nLikely RimWorld Mods directories:\n' >&2
+  candidate_roots=(
+    "${HOME}/.steam/steam"
+    "${HOME}/.local/share/Steam"
+    "${HOME}/snap/steam/common/.local/share/Steam"
+    "${HOME}/Library/Application Support/Steam"
+  )
+  found=0
+  for candidate_root in "${candidate_roots[@]}"; do
+    candidate_mods_dir="${candidate_root}/steamapps/common/RimWorld/Mods"
+    if [[ -d "${candidate_mods_dir}" ]]; then
+      printf '  %s\n' "${candidate_mods_dir}" >&2
+      found=1
+    fi
+  done
+  if [[ "${found}" -eq 0 ]]; then
+    printf '  No common Steam RimWorld Mods directories found.\n' >&2
+  fi
+  printf '\nRun again with one of those Mods directories as the first argument.\n' >&2
+  exit 2
+fi
+
+mods_dir="${1%/}"
+destination="${mods_dir}/${mod_name}"
 
 mkdir -p "$destination"
 

--- a/scripts/rsync-to-rimworld-mods.sh
+++ b/scripts/rsync-to-rimworld-mods.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+default_rimworld_root="/home/christoph/snap/steam/common/.local/share/Steam/steamapps/common/RimWorld"
+rimworld_root="${1:-$default_rimworld_root}"
+mod_name="${2:-AvoidFriendlyFire}"
+destination="${rimworld_root%/}/Mods/${mod_name}"
+
+mkdir -p "$destination"
+
+rsync -av --delete \
+  --include='/About/***' \
+  --include='/Languages/***' \
+  --include='/Textures/***' \
+  --include='/1.6/' \
+  --include='/1.6/Assemblies/' \
+  --include='/1.6/Assemblies/AvoidFriendlyFire.dll' \
+  --exclude='*' \
+  "${repo_root}/" \
+  "${destination}/"
+
+printf 'Synced mod files to %s\n' "$destination"

--- a/src/AvoidFriendlyFire/1.6.csproj
+++ b/src/AvoidFriendlyFire/1.6.csproj
@@ -6,6 +6,7 @@
   
   <PropertyGroup>
     <OutputPath>$(ProjectDir)..\..\1.6\Assemblies\</OutputPath>
+    <AssemblyName>AvoidFriendlyFire</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
## Summary
- Building the RimWorld 1.6 project now produces `AvoidFriendlyFire.dll` and matching symbols instead of inheriting `1.6` from the project filename.
- README build instructions now document the renamed assembly and PDB artifacts.
- Release checks now look for the renamed DLL before packaging without requiring debug symbols.
- The rsync deployment script now requires an explicit RimWorld `Mods` destination and only deploys the release DLL.

## Root Cause
- `1.6.csproj` configured the output directory but did not set an explicit assembly name, so MSBuild used the project filename as the output name.

## Changes
- Added `AssemblyName` to `src/AvoidFriendlyFire/1.6.csproj`.
- Updated README build output documentation.
- Updated `scripts/make-release.sh` to validate `AvoidFriendlyFire.dll`.
- Added the rsync deployment script with no personal default path, no implicit sync when omitted, candidate Mods directory suggestions, and packaging filters limited to `AvoidFriendlyFire.dll`.

## Verification
- `dotnet build src/AvoidFriendlyFire/1.6.csproj`
- `dotnet build src/AvoidFriendlyFire/1.6.csproj --no-restore`
- `bash -n scripts/make-release.sh`
- `bash -n scripts/rsync-to-rimworld-mods.sh`
- `scripts/make-release.sh --dry-run --allow-dirty`
- `scripts/rsync-to-rimworld-mods.sh`
- `scripts/rsync-to-rimworld-mods.sh /tmp/aff-rsync-light-check AvoidFriendlyFire`
- Confirmed `1.6/Assemblies/AvoidFriendlyFire.dll` and `1.6/Assemblies/AvoidFriendlyFire.pdb` were written by the build.
- Confirmed local rsync packaging copies only `AvoidFriendlyFire.dll` under `1.6/Assemblies`.

Fixes #9
